### PR TITLE
Data and Time Scale Bug Fixes, Quality Changes

### DIFF
--- a/Test Building Mechanics/Assets/Scenes/TestBuildingMechanicsScene.unity
+++ b/Test Building Mechanics/Assets/Scenes/TestBuildingMechanicsScene.unity
@@ -7317,6 +7317,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c373fd4cc4070ff46b9e13ed0b2a9bff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SettingsButtonsHandlerScript: {fileID: 1276113749}
   gameDataManagerScript: {fileID: 1276113738}
   gameTimeScaleScript: {fileID: 1276113737}
   pauseMenuCanvas: {fileID: 1840578703}
@@ -7393,6 +7394,7 @@ MonoBehaviour:
   previousPrefabImage: {fileID: 1054425944}
   currentPrefabImage: {fileID: 448199807}
   nextPrefabImage: {fileID: 1743500825}
+  currentPrefabInt: 0
 --- !u!114 &1276113745
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Test Building Mechanics/Assets/Scripts/GameData/GameDataManager.cs
+++ b/Test Building Mechanics/Assets/Scripts/GameData/GameDataManager.cs
@@ -36,8 +36,7 @@ public class GameDataManager : MonoBehaviour
 
         buildingDirectoryPath = Application.persistentDataPath + Path.DirectorySeparatorChar + "Building" + Path.DirectorySeparatorChar;
         buildingDataFilePath = buildingDirectoryPath + "buildingData.json";
-        CreateDirectoryAndFile(buildingDirectoryPath, buildingDataFilePath);
-        File.WriteAllText(buildingDataFilePath, "[]");
+        CreateDirectoryAndFile(buildingDirectoryPath, buildingDataFilePath, "[]");
 
         playerDirectoryPath = Application.persistentDataPath + Path.DirectorySeparatorChar + "Player" + Path.DirectorySeparatorChar;
         playerDataFilePath = playerDirectoryPath + "playerData.json";
@@ -45,12 +44,11 @@ public class GameDataManager : MonoBehaviour
 
         settingsDirectoryPath = Application.persistentDataPath + Path.DirectorySeparatorChar + "Settings" + Path.DirectorySeparatorChar;
         settingsDataFilePath = settingsDirectoryPath + "settings.json";
-        CreateDirectoryAndFile(settingsDirectoryPath, settingsDataFilePath);
     }
 
     private void Start()
     {
-        if (File.ReadAllText(buildingDataFilePath) != "")
+        if (File.ReadAllText(buildingDataFilePath) != "[]")
         {
             buildingDataHandlerScript.LoadBuildings();
         }
@@ -58,7 +56,7 @@ public class GameDataManager : MonoBehaviour
         {
             playerDataHandlerScript.LoadPlayerStats();
         }
-        if (File.ReadAllText(settingsDataFilePath) != "")
+        if (File.ReadAllText(settingsDataFilePath) != "{}")
         {
             settingsDataHandlerScript.LoadSettings();
         }
@@ -91,17 +89,19 @@ public class GameDataManager : MonoBehaviour
         settingsDataHandlerScript.settingsData = JsonConvert.DeserializeObject<SettingsData>(File.ReadAllText(settingsDataFilePath), serializerSettings);
     }
 
-    public void CreateDirectoryAndFile(string directoryPath, string filePath)
+    public void CreateDirectoryAndFile(string directoryPath, string filePath, string writeIn = "")
     {
         if ((!File.Exists(filePath) && !Directory.Exists(directoryPath)))
         {
             Directory.CreateDirectory(directoryPath);
 
             File.Create(filePath).Dispose();
+            File.WriteAllText(filePath, writeIn);
         }
         else if (!File.Exists(filePath))
         {
             File.Create(filePath).Dispose();
+            File.WriteAllText(filePath, writeIn);
         }
     }
 }

--- a/Test Building Mechanics/Assets/Scripts/GameData/MainMenuDataManager.cs
+++ b/Test Building Mechanics/Assets/Scripts/GameData/MainMenuDataManager.cs
@@ -26,12 +26,12 @@ public class MainMenuDataManager : MonoBehaviour
 
         settingsDirectoryPath = Application.persistentDataPath + Path.DirectorySeparatorChar + "Settings" + Path.DirectorySeparatorChar;
         settingsDataFilePath = settingsDirectoryPath + "settings.json";
-        CreateDirectoryAndFile(settingsDirectoryPath, settingsDataFilePath);
+        CreateDirectoryAndFile(settingsDirectoryPath, settingsDataFilePath, "{}");
     }
 
     private void Start()
     {
-        if (File.ReadAllText(settingsDataFilePath) != "")
+        if (File.ReadAllText(settingsDataFilePath) != "{}")
         {
             settingsDataHandlerScript.LoadSettings();
         }
@@ -47,17 +47,19 @@ public class MainMenuDataManager : MonoBehaviour
         settingsDataHandlerScript.settingsData = JsonConvert.DeserializeObject<SettingsData>(File.ReadAllText(settingsDataFilePath), serializerSettings);
     }
 
-    public void CreateDirectoryAndFile(string directoryPath, string filePath)
+    public void CreateDirectoryAndFile(string directoryPath, string filePath, string writeIn = "")
     {
         if ((!File.Exists(filePath) && !Directory.Exists(directoryPath)))
         {
             Directory.CreateDirectory(directoryPath);
 
             File.Create(filePath).Dispose();
+            File.WriteAllText(filePath, writeIn);
         }
         else if (!File.Exists(filePath))
         {
             File.Create(filePath).Dispose();
+            File.WriteAllText(filePath, writeIn);
         }
     }
 }

--- a/Test Building Mechanics/Assets/Scripts/GameData/SettingsData/SettingsDataHandler.cs
+++ b/Test Building Mechanics/Assets/Scripts/GameData/SettingsData/SettingsDataHandler.cs
@@ -14,8 +14,8 @@ public class SettingsDataHandler : MonoBehaviour
 
     public TMP_Dropdown qualityDropdown;
 
-    [HideInInspector] public SettingsData settingsData;
-    [HideInInspector] public int qualityLevel;
+    [HideInInspector] public SettingsData settingsData = new SettingsData();
+    [HideInInspector] public int qualityLevel = -1;
     public Dictionary<string, KeyCode> keybindsDictionary = new Dictionary<string, KeyCode>();
 
     public void SaveSettings()

--- a/Test Building Mechanics/Assets/Scripts/Handlers/GameButtonsHandler.cs
+++ b/Test Building Mechanics/Assets/Scripts/Handlers/GameButtonsHandler.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 
 public class GameButtonsHandler : MonoBehaviour
 {
+    public SettingsButtonsHandler SettingsButtonsHandlerScript;
     public GameDataManager gameDataManagerScript;
     public GameTimeScale gameTimeScaleScript;
 
@@ -25,6 +26,8 @@ public class GameButtonsHandler : MonoBehaviour
 
     public void QuitToMenu()
     {
+        Time.timeScale = 1.0f;
+        SettingsButtonsHandlerScript.SaveAndApplyButton();
         gameDataManagerScript.WriteData();
 
         SceneManager.LoadScene(0);
@@ -32,6 +35,7 @@ public class GameButtonsHandler : MonoBehaviour
 
     public void QuitGame()
     {
+        SettingsButtonsHandlerScript.SaveAndApplyButton();
         gameDataManagerScript.WriteData();
 
         Application.Quit();

--- a/Test Building Mechanics/Packages/manifest.json
+++ b/Test Building Mechanics/Packages/manifest.json
@@ -5,7 +5,6 @@
     "com.unity.render-pipelines.universal": "14.0.8",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.timeline": "1.7.4",
     "com.unity.ugui": "1.0.0",
     "jillejr.newtonsoft.json-for-unity.converters": "1.5.1",
     "com.unity.modules.ai": "1.0.0",

--- a/Test Building Mechanics/Packages/packages-lock.json
+++ b/Test Building Mechanics/Packages/packages-lock.json
@@ -97,18 +97,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.timeline": {
-      "version": "1.7.4",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.director": "1.0.0",
-        "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
-        "com.unity.modules.particlesystem": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ugui": {
       "version": "1.0.0",
       "depth": 0,

--- a/Test Building Mechanics/ProjectSettings/ProjectSettings.asset
+++ b/Test Building Mechanics/ProjectSettings/ProjectSettings.asset
@@ -22,7 +22,7 @@ PlayerSettings:
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 1
-  m_SplashScreenDrawMode: 0
+  m_SplashScreenDrawMode: 1
   m_SplashScreenBackgroundAnimationZoom: 1
   m_SplashScreenLogoAnimationZoom: 1
   m_SplashScreenBackgroundLandscapeAspect: 1
@@ -39,7 +39,9 @@ PlayerSettings:
     y: 0
     width: 1
     height: 1
-  m_SplashScreenLogos: []
+  m_SplashScreenLogos:
+  - logo: {fileID: 10404, guid: 0000000000000000f000000000000000, type: 0}
+    duration: 2
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1024

--- a/Test Building Mechanics/ProjectSettings/QualitySettings.asset
+++ b/Test Building Mechanics/ProjectSettings/QualitySettings.asset
@@ -155,7 +155,7 @@ QualitySettings:
     excludedTargetPlatforms: []
   m_TextureMipmapLimitGroupNames: []
   m_PerPlatformDefaultQuality:
-    Android: 1
+    Android: 0
     CloudRendering: 2
     GameCoreScarlett: 2
     GameCoreXboxOne: 2
@@ -165,9 +165,9 @@ QualitySettings:
     PS5: 2
     Server: 0
     Stadia: 2
-    Standalone: 2
+    Standalone: 0
     WebGL: 1
     Windows Store Apps: 2
     XboxOne: 2
-    iPhone: 1
+    iPhone: 0
     tvOS: 1


### PR DESCRIPTION
### Changes:
 - Changed default Quality Level to Performant in Player Settings within Unity, so the Quality Dropdown would match with the default Quality Level on first boot
 - Added optional writeIn string variable in CreateDirectoryAndFile() method in both GameDataManager.cs and MainMenuDataManager.cs so that if we needed to initialize any data.json, we can

### Bug Fixes:
 - Fixed a bug that would cause 'null' to be written to settingsData.json
   - Fixed by writing "{}" to settingsData.json on creation of file
 - Fixed a bug that would cause everything in buildingData.json to be overwritten with "[]", even if buildingData.json already had elements in the file
   - Fixed by, instead of always writing "[]" to buildingData.json on Awake(), we do it in the CreateDirectoryAndFile() void in GameDataManager.cs. This way, "[]" is only written if we haven't created the file
 - Fixed a bug that, if user starts the main game, quits to menu, then goes back to main game, the user couldn't interact or play with anything
   - Fixed by on QuitToMainMenu() in GameButtonsHandler.cs, we set Time Scale back to 1, because it's set to 0 on pause

### Known Bugs:
 - None